### PR TITLE
Change aarch64 URL path to arm64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl Extension {
                 "https://github.com/g-plane/wasm-language-tools/releases/download/{}/wat_server-{}-{}.zip",
                 release.version,
                 match arch {
-                    Architecture::Aarch64 => "arm",
+                    Architecture::Aarch64 => "arm64",
                     Architecture::X8664 => "x86_64",
                     Architecture::X86=>"x86",
                 },


### PR DESCRIPTION
The release path in the language server Github repo uses `arm64` in the URL rather than `arm`.  Without this change, the language server download ends up with `404` errors.